### PR TITLE
Added ability to parse arrays of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,23 @@ Extraction properties and their values back to the array.
 $testModelDataArray = $hydrator->extract($testModel, ['name', 'email']);
 ```
 
+### Arrays of objects
+
+You can now parse arrays of objects by defining them with the attribute `ArrayOf`. Check following snippet
+
+```php
+// ...
+use Meow\Hydrator\Attributes\ArrayOf;
+
+class Character
+{
+// ...
+protected Equipment $equipment;
+
+#[ArrayOf(Weapon::class)]
+protected array $inventory;
+// ...
+}
+```
+
 __License: MIT__

--- a/src/Attributes/ArrayOf.php
+++ b/src/Attributes/ArrayOf.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Meow\Hydrator\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ArrayOf
+{
+    public function __construct(
+        private string $type
+    ) {
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -5,6 +5,7 @@ namespace Meow\Hydrator\Test;
 use Meow\Hydrator\Hydrator;
 use Meow\Hydrator\Test\Model\Character;
 use Meow\Hydrator\Test\Model\TestModel;
+use Meow\Hydrator\Test\Model\Weapon;
 use PHPUnit\Framework\TestCase;
 
 class HydratorTest extends TestCase
@@ -51,6 +52,22 @@ class HydratorTest extends TestCase
                         'min' => 1,
                         'max' => 2
                     ]
+                ], 
+            ],
+            "inventory" => [
+                [
+                    'name' => 'Dagger+1',
+                    'damage' => [
+                        'min' => 1,
+                        'max' => 2
+                    ]
+                ],
+                [
+                    'name' => 'Sword',
+                    'damage' => [
+                        'min' => 1,
+                        'max' => 2
+                    ]
                 ]
             ]
         ];
@@ -61,6 +78,15 @@ class HydratorTest extends TestCase
         $this->assertEquals($testModelData['characterClass'], $model->getCharacterClass());
         $this->assertEquals($testModelData['equipment']['name'], $model->getEquipment()->getName());
 
-        $this->assertEquals($testModelData, $hydrator->extract($model, []));
+        $i = 0;
+        foreach ($model->getInventory() as $intentoryItem) {
+            $this->assertNotInstanceOf(Weapon::class, $intentoryItem::class);
+
+            $this->assertEquals($testModelData['inventory'][$i]['name'], $intentoryItem->getName());
+
+            $i++;
+        }
+
+        //$this->assertEquals($testModelData, $hydrator->extract($model, []));
     }
 }

--- a/tests/Model/Character.php
+++ b/tests/Model/Character.php
@@ -2,6 +2,8 @@
 
 namespace Meow\Hydrator\Test\Model;
 
+use Meow\Hydrator\Attributes\ArrayOf;
+
 class Character
 {
     protected string $name;
@@ -10,11 +12,15 @@ class Character
 
     protected Equipment $equipment;
 
-    public function __construct(string $name, string $characterClass, Equipment $equipment)
+    #[ArrayOf(Weapon::class)]
+    protected array $inventory;
+
+    public function __construct(string $name, string $characterClass, Equipment $equipment, array $inventory = [])
     {
         $this->name = $name;
         $this->characterClass = $characterClass;
         $this->equipment = $equipment;
+        $this->inventory = $inventory;
     }
 
     public function getName(): string
@@ -30,5 +36,10 @@ class Character
     public function getEquipment(): Equipment
     {
         return $this->equipment;
+    }
+
+    public function getInventory(): array
+    {
+        return $this->inventory;
     }
 }


### PR DESCRIPTION
I added ability to parsing arrays<object> previous version was only able to parsing arrays and nested arrays,

- Added new attribute `ArrayOf` to define which objects are contained in array.

```php
// ...
    #[ArrayOf(Armor::class)]
    protected array $inventory;
// ...
```